### PR TITLE
GetSharedAccessPath would not return due to UTC / DateTimeOffset issue

### DIFF
--- a/AzureBlobFileSystem.Test/StorageUniversalTest.cs
+++ b/AzureBlobFileSystem.Test/StorageUniversalTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -205,6 +206,44 @@ namespace AzureBlobFileSystem.Test
             SUT.RenameFolder(folder, folder + "2");
 
             Assert.AreEqual("f1", SUT.ListFiles(folder + "2").Single().GetName());
+        }
+
+        [Test]
+        public void sharedPath_should_return_when_given_offset()
+        {
+            var folder = SUT.Combine(TEST_FOLDER, "folder");
+            SUT.CreateFolder(folder);
+
+            SUT.CreateFile(SUT.Combine(folder, "f1"));
+
+            var offset = DateTimeOffset.MaxValue;
+
+            Assert.DoesNotThrow(() =>
+            {
+                var file = SUT.ListFiles(folder).First();
+                var path = file.GetPath();
+                var sharedPath = file.GetSharedAccessPath(offset);
+                Trace.WriteLine(path);
+                Trace.WriteLine(sharedPath);
+            });
+        }
+
+        [Test]
+        public void sharedPath_should_return_when_not_given_offset()
+        {
+            var folder = SUT.Combine(TEST_FOLDER, "folder");
+            SUT.CreateFolder(folder);
+
+            SUT.CreateFile(SUT.Combine(folder, "f1"));
+
+            Assert.DoesNotThrow(() =>
+            {
+                var file = SUT.ListFiles(folder).First();
+                var path = file.GetPath();
+                var sharedPath = file.GetSharedAccessPath();
+                Trace.WriteLine(path);
+                Trace.WriteLine(sharedPath);
+            });
         }
     }
 }

--- a/AzureBlobFileSystem/AzureBlobStorageProvider.cs
+++ b/AzureBlobFileSystem/AzureBlobStorageProvider.cs
@@ -103,6 +103,8 @@ namespace AzureBlobFileSystem
             return container.BlobExists(path);
         }
 
+        public DateTimeOffset? DefaultSharedAccessExpiration { get; set; }
+
         public IEnumerable<IStorageFile> ListFiles(string path)
         {
             path = path ?? String.Empty;
@@ -417,12 +419,12 @@ namespace AzureBlobFileSystem
             {
                 return Path.GetExtension(GetPath());
             }
-
-            public string GetSharedAccessPath()
+            
+            public string GetSharedAccessPath(DateTimeOffset? expiration = null)
             {
                 return _blob.Uri.AbsoluteUri + _blob.GetSharedAccessSignature(new SharedAccessBlobPolicy()
                 {
-                    SharedAccessExpiryTime = DateTime.MaxValue
+                    SharedAccessExpiryTime = expiration ?? _azureFileSystem.DefaultSharedAccessExpiration
                 }, "default");
             }
 

--- a/AzureBlobFileSystem/FileSystemStorageProvider.cs
+++ b/AzureBlobFileSystem/FileSystemStorageProvider.cs
@@ -306,6 +306,8 @@ namespace AzureBlobFileSystem
             return new FileInfo(MapStorage(path)).Exists;
         }
 
+        public DateTimeOffset? DefaultSharedAccessExpiration { get; set; }
+
         public IStorageFile CreateOrReplaceFile(string path)
         {
             if (FileExists(path))
@@ -359,7 +361,7 @@ namespace AzureBlobFileSystem
                 return _fileInfo.Extension;
             }
 
-            public string GetSharedAccessPath()
+            public string GetSharedAccessPath(DateTimeOffset? expiration = null)
             {
                 return _path;
             }

--- a/AzureBlobFileSystem/IStorageFile.cs
+++ b/AzureBlobFileSystem/IStorageFile.cs
@@ -10,7 +10,7 @@ namespace AzureBlobFileSystem
         long GetSize();
         DateTime GetLastUpdated();
         string GetFileType();
-        string GetSharedAccessPath();
+        string GetSharedAccessPath(DateTimeOffset? expiration = null);
 
         /// <summary>
         /// Creates a stream for reading from the file.

--- a/AzureBlobFileSystem/IStorageProvider.cs
+++ b/AzureBlobFileSystem/IStorageProvider.cs
@@ -103,5 +103,14 @@ namespace AzureBlobFileSystem
         string Combine(string path1, string path2);
 
         bool FileExists(string path);
+
+
+        /// <summary>
+        /// Gets or sets the default shared access expiration date.
+        /// </summary>
+        /// <value>
+        /// The default shared access expiration date.
+        /// </value>
+        DateTimeOffset? DefaultSharedAccessExpiration { get; set; }
     }
 }


### PR DESCRIPTION
Great library, but I encountered failures with GetSharedAccessPath (incidentally, one of the few methods without test coverage).  This commit resolves the issue and exposes the ability to set a default expiration offset.