### PR TITLE
Add ability to set permissions when retrieving SAS-based URL

### DIFF
--- a/AzureBlobFileSystem/AzureBlobFileSystem.csproj
+++ b/AzureBlobFileSystem/AzureBlobFileSystem.csproj
@@ -79,6 +79,7 @@
     <Compile Include="IStorageProvider.cs" />
     <Compile Include="PathValidation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SasPermissionFlags.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/AzureBlobFileSystem/FileSystemStorageProvider.cs
+++ b/AzureBlobFileSystem/FileSystemStorageProvider.cs
@@ -361,7 +361,7 @@ namespace AzureBlobFileSystem
                 return _fileInfo.Extension;
             }
 
-            public string GetSharedAccessPath(DateTimeOffset? expiration = null)
+            public string GetSharedAccessPath(DateTimeOffset? expiration = null, SasPermissionFlags permissions = SasPermissionFlags.Read)
             {
                 return _path;
             }

--- a/AzureBlobFileSystem/IStorageFile.cs
+++ b/AzureBlobFileSystem/IStorageFile.cs
@@ -10,7 +10,7 @@ namespace AzureBlobFileSystem
         long GetSize();
         DateTime GetLastUpdated();
         string GetFileType();
-        string GetSharedAccessPath(DateTimeOffset? expiration = null);
+        string GetSharedAccessPath(DateTimeOffset? expiration = null, SasPermissionFlags permissions = SasPermissionFlags.Read);
 
         /// <summary>
         /// Creates a stream for reading from the file.

--- a/AzureBlobFileSystem/SasPermissionFlags.cs
+++ b/AzureBlobFileSystem/SasPermissionFlags.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace AzureBlobFileSystem
+{
+    /// <summary>
+    /// Specifies the set of possible permissions for a shared access policy.
+    /// This mirrors the flags available in the Azure Storage Client Library
+    /// </summary>
+    [Flags]
+    public enum SasPermissionFlags
+    {
+        None = 0,
+        Read = 1,
+        Write = 2,
+        Delete = 4,
+        List = 8,
+    }
+}


### PR DESCRIPTION
Jan @pofider, I found another use case I needed on my end that should be useful.  This change allows you set the type of permissions for the Shared Access URL that is generated and defaults to read-only.
